### PR TITLE
PE: Sprites disappear when health < 100. Hard one to find, but got it!

### DIFF
--- a/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/DarkSDKMore/DarkLUA/DarkLUA.cpp
+++ b/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/DarkSDKMore/DarkLUA/DarkLUA.cpp
@@ -2774,11 +2774,6 @@ luaMessage** ppLuaMessages = NULL;
 	 {
 		 fReturnHeight = fHitY;
 	 }
-	 else
-	 {
-		 //PE: Failed.
-		 printf("tmp");
-	 }
 	 #else
 	 fReturnHeight = GetLUATerrainHeightEx(fX, fZ);
 	 #endif

--- a/GameGuru Core/GameGuru/Source/M-Game.cpp
+++ b/GameGuru Core/GameGuru/Source/M-Game.cpp
@@ -2773,6 +2773,8 @@ bool game_masterroot_gameloop_loopcode(int iUseVRTest)
 				bRenderTabTab = true;
 				bBlockImGuiUntilNewFrame = false;
 				bImGuiRenderWithNoCustomTextures = false;
+				extern bool bSpriteWinVisible;
+				bSpriteWinVisible = false;
 			}
 
 			ImGuiViewport* mainviewport = ImGui::GetMainViewport();

--- a/GameGuru Core/GameGuru/Source/M-Postprocess.cpp
+++ b/GameGuru Core/GameGuru/Source/M-Postprocess.cpp
@@ -586,6 +586,8 @@ void postprocess_setscreencolor ( void )
 			bRenderTabTab = true;
 			bBlockImGuiUntilNewFrame = false;
 			bImGuiRenderWithNoCustomTextures = false;
+			extern bool bSpriteWinVisible;
+			bSpriteWinVisible = false;
 		}
 
 		ImGuiViewport* mainviewport = ImGui::GetMainViewport();


### PR DESCRIPTION

List:
* Fixed - GG Max - The standard rotating radar stops displaying when player health falls below 99 hp ( https://github.com/TheGameCreators/GameGuruRepo/issues/4441 )