### PR TITLE
PE: Bug Fixes - Custom Shaders - DeSaturation ...

### DIFF
--- a/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/Sound/CSoundC.cpp
+++ b/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/Sound/CSoundC.cpp
@@ -1079,6 +1079,7 @@ DARKSDK void PlaySound ( int iID )
 			}
 		}
 		wiAudio::Stop(&sound->soundinstance); //Flush so restart.
+		wiAudio::Play(&sound->soundinstance); //PE: Start immediately.
 		sound->Play();
 	}
 	else

--- a/GameGuru Core/GameGuru/Imgui/imgui_gg_dx11.cpp
+++ b/GameGuru Core/GameGuru/Imgui/imgui_gg_dx11.cpp
@@ -6984,6 +6984,8 @@ void ParseLuaScriptWithElementID(entityeleproftype *tmpeleprof, char * script, i
 					#ifdef WICKEDENGINE
 					if (pestrcasestr(tmpVariable, "@"))
 						tmpeleprof->PropertiesVariable.VariableType[tmpeleprof->PropertiesVariable.iVariables] = 4; // labelled int[]
+					if (pestrcasestr(tmpVariable, "@@"))
+						tmpeleprof->PropertiesVariable.VariableType[tmpeleprof->PropertiesVariable.iVariables] = 7; // labelled string
 					if (pestrcasestr(tmpVariable, "*"))
 						tmpeleprof->PropertiesVariable.VariableType[tmpeleprof->PropertiesVariable.iVariables] = 5; // user specified in seconds
 					if (pestrcasestr(tmpVariable, "&"))
@@ -7009,7 +7011,7 @@ void ParseLuaScriptWithElementID(entityeleproftype *tmpeleprof, char * script, i
 
 							#ifdef WICKEDENGINE
 							// Need to calculate the range differently for the dropdown type.
-							if (tmpeleprof->PropertiesVariable.VariableType[tmpeleprof->PropertiesVariable.iVariables] == 4)
+							if (tmpeleprof->PropertiesVariable.VariableType[tmpeleprof->PropertiesVariable.iVariables] == 4 || tmpeleprof->PropertiesVariable.VariableType[tmpeleprof->PropertiesVariable.iVariables] == 7)
 							{
 								// Count number of = symbols
 								int iFirstEqualsIndex = -1;
@@ -7846,11 +7848,15 @@ int DisplayLuaDescription(entityeleproftype *tmpeleprof)
 				if (pTooltipForTickbox && ImGui::IsItemHovered()) ImGui::SetTooltip(pTooltipForTickbox);
 			}
 			#ifdef WICKEDENGINE
-			else if (tmpeleprof->PropertiesVariable.VariableType[i] == 4)
+			else if (tmpeleprof->PropertiesVariable.VariableType[i] == 4 || tmpeleprof->PropertiesVariable.VariableType[i] == 7)
 			{
 				// Dropdown of labelled integers.
 				std::vector<std::string> labels;
 				bool bGotLabels = false;
+				bool bAsString = false;
+				if (tmpeleprof->PropertiesVariable.VariableType[i] == 7)
+					bAsString = true;
+
 				// Retrieve the labels for this dropdown.
 				for (int l = 0; l < luadropdownlabels.size(); l++)
 				{
@@ -7870,14 +7876,20 @@ int DisplayLuaDescription(entityeleproftype *tmpeleprof)
 					int iQuestIndex = 0;
 
 					// Determine the label for the currently selected value.
-					int iSelectedIndex = atol(tmpeleprof->PropertiesVariable.VariableValue[i]) - tmpeleprof->PropertiesVariable.VariableValueFrom[i];
-
-					// Since the first element of the labels is the variable number, add 1.
-					iSelectedIndex++;
-
-					// Ensure preview for combo is always valid
+					int iSelectedIndex = 0;
 					const char* preview = "";
-					if (iSelectedIndex < labels.size() ) preview = labels[iSelectedIndex].c_str();
+					if (bAsString)
+					{
+						preview = tmpeleprof->PropertiesVariable.VariableValue[i];
+					}
+					else
+					{
+						iSelectedIndex = atol(tmpeleprof->PropertiesVariable.VariableValue[i]) - tmpeleprof->PropertiesVariable.VariableValueFrom[i];
+						// Since the first element of the labels is the variable number, add 1.
+						iSelectedIndex++;
+						// Ensure preview for combo is always valid
+						if (iSelectedIndex < labels.size()) preview = labels[iSelectedIndex].c_str();
+					}
 
 					// No combi if no choices
 					if (tmpeleprof->PropertiesVariable.VariableValueTo[i] == 0 && tmpeleprof->PropertiesVariable.VariableValueFrom[i] == 0)
@@ -7897,16 +7909,28 @@ int DisplayLuaDescription(entityeleproftype *tmpeleprof)
 								int iValue = tmpeleprof->PropertiesVariable.VariableValueFrom[i] + j;
 								sprintf(labelID, "%d", iValue-1);
 
-								if (strcmp(labelID, tmpeleprof->PropertiesVariable.VariableValue[i]) == NULL)
-									bSelected = true;
-
 								char label[128];
-								
-								strcpy(label, labels[j].c_str());
-								
+								strcpy_s(label, 127,  labels[j].c_str());
+								label[127] = 0;
+
+								if (bAsString)
+								{
+									if (strcmp(label, tmpeleprof->PropertiesVariable.VariableValue[i]) == NULL)
+										bSelected = true;
+								}
+								else
+								{
+									if (strcmp(labelID, tmpeleprof->PropertiesVariable.VariableValue[i]) == NULL)
+										bSelected = true;
+								}
+							
 								if (ImGui::Selectable(label, bSelected))
 								{
-									strcpy(tmpeleprof->PropertiesVariable.VariableValue[i], labelID);
+									if(bAsString)
+										strcpy(tmpeleprof->PropertiesVariable.VariableValue[i], label);
+									else
+										strcpy(tmpeleprof->PropertiesVariable.VariableValue[i], labelID);
+
 									bUpdateMainString = true;
 								}
 								if (bSelected) ImGui::SetItemDefaultFocus();

--- a/GameGuru Core/GameGuru/Imgui/imgui_gg_dx11.cpp
+++ b/GameGuru Core/GameGuru/Imgui/imgui_gg_dx11.cpp
@@ -7184,6 +7184,39 @@ void ParseLuaScriptWithElementID(entityeleproftype *tmpeleprof, char * script, i
 													tmpeleprof->PropertiesVariable.VariableValueTo[tmpeleprof->PropertiesVariable.iVariables] = 0;
 												}
 											}
+											if (stricmp(labels[1].c_str(), "hudscreenlist") == NULL)
+											{
+												static std::vector<std::string> globallist_labels;
+												extern StoryboardStruct Storyboard;
+												labels.clear();
+												labels.push_back(cVariable);
+
+												for (int allhudscreensnodeid = 0; allhudscreensnodeid < STORYBOARD_MAXNODES; allhudscreensnodeid++)
+												{
+													if (Storyboard.Nodes[allhudscreensnodeid].used)
+													{
+														if (Storyboard.Nodes[allhudscreensnodeid].type == STORYBOARD_TYPE_HUD)
+														{
+															if (strlen(Storyboard.Nodes[allhudscreensnodeid].title) > 0)
+															{
+																labels.push_back(Storyboard.Nodes[allhudscreensnodeid].title);
+
+															}
+														}
+													}
+												}
+												if (labels.size() > 1)
+												{
+													tmpeleprof->PropertiesVariable.VariableValueFrom[tmpeleprof->PropertiesVariable.iVariables] = 1;
+													tmpeleprof->PropertiesVariable.VariableValueTo[tmpeleprof->PropertiesVariable.iVariables] = labels.size();
+												}
+												else
+												{
+													tmpeleprof->PropertiesVariable.VariableValueFrom[tmpeleprof->PropertiesVariable.iVariables] = 0;
+													tmpeleprof->PropertiesVariable.VariableValueTo[tmpeleprof->PropertiesVariable.iVariables] = 0;
+												}
+
+											}
 											if (stricmp(labels[1].c_str(), "globallist") == NULL)
 											{
 												static std::vector<std::string> globallist_labels;
@@ -7239,7 +7272,7 @@ void ParseLuaScriptWithElementID(entityeleproftype *tmpeleprof, char * script, i
 													}
 												}
 												labels = globallist_labels;
-												if (labels.size() > 0)
+												if (labels.size() > 1)
 												{
 													tmpeleprof->PropertiesVariable.VariableValueFrom[tmpeleprof->PropertiesVariable.iVariables] = 1;
 													tmpeleprof->PropertiesVariable.VariableValueTo[tmpeleprof->PropertiesVariable.iVariables] = labels.size();

--- a/GameGuru Core/GameGuru/Source/M-LUA-Entity.cpp
+++ b/GameGuru Core/GameGuru/Source/M-LUA-Entity.cpp
@@ -675,10 +675,31 @@ bool entity_lua_manageactivationresult (int iEntityID)
 		{
 			// show/hide if particle based on activation state
 			if (t.entityelement[iEntityID].activated == 1)
+			{
+				bool bJustCreated = false;
+				if (t.entityelement[iEntityID].eleprof.newparticle.bParticle_Show_At_Start == false)
+				{
+					bJustCreated = true;
+				}
 				t.entityelement[iEntityID].eleprof.newparticle.bParticle_Show_At_Start = true;
+				entity_updateparticleemitter(iEntityID);
+
+				if (bJustCreated)
+				{
+					int iParticleEmitter = t.entityelement[iEntityID].eleprof.newparticle.emitterid;
+					if (iParticleEmitter != -1)
+					{
+						GPUParticles::gpup_setParticleScale(iParticleEmitter, t.entityelement[iEntityID].eleprof.newparticle.bParticle_Size);
+						GPUParticles::gpup_setEffectAnimationSpeed(iParticleEmitter, t.entityelement[iEntityID].eleprof.newparticle.fParticle_Speed);
+						GPUParticles::gpup_setEffectOpacity(iParticleEmitter, t.entityelement[iEntityID].eleprof.newparticle.fParticle_Opacity);
+					}
+				}
+			}
 			else
+			{
 				t.entityelement[iEntityID].eleprof.newparticle.bParticle_Show_At_Start = false;
-			entity_updateparticleemitter(iEntityID);
+				entity_updateparticleemitter(iEntityID);
+			}
 		}
 	}
 

--- a/GameGuru Core/GameGuru/Source/M-LUA.cpp
+++ b/GameGuru Core/GameGuru/Source/M-LUA.cpp
@@ -298,7 +298,7 @@ void lua_execute_properties_variable(char *string)
 					if (type == 1) {
 						LuaPushFloat( atof(find+1) );
 					}
-					else if (type == 2) {
+					else if (type == 2 || type == 7) {
 						LuaPushString(find+1);
 					}
 					else {

--- a/Scripts/scriptbank/gameplayercontrol.lua
+++ b/Scripts/scriptbank/gameplayercontrol.lua
@@ -2221,7 +2221,11 @@ end
 
 function gameplayercontrol.combatmusic()
  -- handle combat music track control (fades out after no combat)
- if g_CombatMusicMode == nil then g_CombatMusicMode = 0 end
+ if g_CombatMusicMode == nil then
+   g_CombatMusicVolume = 0.2
+   g_CombatMusicMode = 2
+   g_CombatMusicLatest = 0
+ end
  if g_PlayerHealth <= 0 then 
   StopCombatMusicTrack()
   g_CombatMusicMode = 0 


### PR DESCRIPTION
PE: Bug Fixes - Custom Shaders - DeSaturation ...
PE: Added DLUA hud list "(0=hudscreenlist)" (4 Necrym59).
PE: Added DLUA - Any list can now return result as string. Use two "@@" instead of one. (4 Necrym59).
PE: Bug Fix - Do not start combat music at start of level, only when a actual combat is starting.
PE: Bug Fix - XAudio2 stop start sound immediately to stop small delays with fast playing sounds. ( https://github.com/TheGameCreators/GameGuruRepo/issues/5985#issuecomment-2843807797 )
PE: Bug Fix - Particles do not restore opacity and speed when created in standalone. ( https://github.com/TheGameCreators/GameGuruRepo/issues/5991 )
