### PR TITLE
Correct GitHub repo links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,67 @@
 # The GameGuru MAX Repository
 
-This is not open source and remains copyright, see "Max\Guides\EULA.txt" for more information on license matters. This repository contains the current source code for GameGuru MAX and is under continual development.
+This is not open source and remains copyright, see "[Max\Guides\EULA.txt](https://github.com/Dark-Basic-Software-Limited/GameGuruMAX/blob/main/Guides/EULA.txt)" for more information on license matters. This repository contains the current source code for GameGuru MAX and is under continual development.
 
 GameGuru MAX is a 3D game maker for simple first-person games and is available to buy from Steam: https://store.steampowered.com/app/1247290?utm_source=github&utm_campaign=general&utm_medium=web
 
 You will need the media files associated with the above product to use this repository.
 
-This source code requires Visual Studio 2022 Community Edition. Select the "Desktop Development with C++" theme. Ensure you add Visual C++ MFC for x86 and x64 to a clean install of VS2022. Also, untick the Windows 11 SDKs and tick the most recent Windows 10 SDK. You can also untick the Boost and Google Tests. The install should be about 10 GB.
+This source code requires `Visual Studio 2022 Community Edition`. Select the "`Desktop Development with C++`" theme. Ensure you add `Visual C++ MFC for x86 and x64` to a clean install of VS2022. Also, untick the `Windows 11 SDKs` and tick the most recent `Windows 10 SDK`. You can also untick the `Boost and Google Tests`. The install should be about 10 GB.
 
 Steps to compiling and running GameGuru MAX:
 
-Compiling WICKED ENGINE:
+## Cloning and Compiling WICKED ENGINE:
 
 1. Create a DEV folder somewhere close to a root drive with lots of storage
 2. Install GitHub Desktop and log in with a previously registered GitHub account
-3. Use GitHub and go click the green CODE button to copy the repo URL: https://github.com/TheGameCreators/WickedRepo
-4. Use GitHub Desktop to CLONE this repository and name it WICKEDREPO located in the DEV folder (i.e. D:\DEV\WICKEDREPO)
+3. Use GitHub and click the green ![CODE](https://img.shields.io/badge/CODE-006400?style=flat&logoColor=white) button on [GameGuruMAX](https://github.com/Dark-Basic-Software-Limited/GameGuruMAX) to copy the repo web URL: https://github.com/Dark-Basic-Software-Limited/WickedRepo
+4. Use GitHub Desktop to CLONE this repository and name it WICKEDREPO located in the DEV folder (i.e. `D:\DEV\WICKEDREPO`)
 5. You will need to log into your GitHub account within GitHub Desktop
 6. Select CLONE a repository from the internet and select UTL, enter the URL you copied earlier
-7. Change the LOCAL PATH to your DEV folder and name this repo folder WICKEDREPO (i.e. D:\DEV\WICKEDREPO)
-8. Open "D:\DEV\WICKEDREPO\WickedEngine.sln" (use VS2022) and right click 'WickedEngine_Windows' project and select "Set as Startup Project" 
-9. Set the Solution Configuration from "Debug" to "ReleaseForGG". Now right click 'WickedEngine_Windows' project and select Properties
-10. Ensure your project properties "Output Directory" in General looks like: "$(SolutionDir)..\GAMEGURUMAXREPO\GameGuru Core\Guru-WickedMAX\x64\Release\"
-11. Right click 'WickedEngine_Windows' project and select REBUILD, it should produce a file "DEV\GAMEGURUMAXREPO\GameGuru Core\Guru-WickedMAX\x64\Release\WickedEngine_Windows.lib".
+7. Change the LOCAL PATH to your DEV folder and name this repo folder WICKEDREPO (i.e. `D:\DEV\WICKEDREPO`)
+8. Open "`D:\DEV\WICKEDREPO\WickedEngine.sln`" (use VS2022) and right click '`WickedEngine_Windows`' project and select "`Set as Startup Project`" 
+9. Set the Solution Configuration from "`Debug`" to "`ReleaseForGG`". Now right click '`WickedEngine_Windows`' project and select Properties
+10. Ensure your project properties "`Output Directory`" in General looks like: "`$(SolutionDir)..\GAMEGURUMAXREPO\GameGuru Core\Guru-WickedMAX\x64\Release\`"
+11. Right click '`WickedEngine_Windows`' project and select REBUILD, it should produce a file "`DEV\GAMEGURUMAXREPO\GameGuru Core\Guru-WickedMAX\x64\Release\WickedEngine_Windows.lib`".
 12. Close Visual Studio
 
-Cloning ASSIMP:
+## Cloning ASSIMP:
 
-1. The "GameGuru MAX Missing LIBs" zip (see below) contains the required ASSIMP.LIB file, but you will need ASSIMP repo side by side with the other repos
-2. Use GitHub to get the CODE URL so you can clone the following URL: https://github.com/TheGameCreators/assimp
-3. Ensure the name you give for the local folder inside DEV is ASSIMP (i.e. D:\DEV\ASSIMP). Use capitals.
+1. The "`GameGuru MAX Missing LIBs`" zip (see below) contains the required `ASSIMP.LIB` file, but you will need ASSIMP repo side by side with the other repos
+2. Use GitHub and click the green ![CODE](https://img.shields.io/badge/CODE-006400?style=flat&logoColor=white) button on [assimp](https://github.com/Dark-Basic-Software-Limited/assimp) to copy the repo URL so you can clone the repo web URL: https://github.com/Dark-Basic-Software-Limited/assimp
+3. Ensure the name you give for the local folder inside `DEV` is `ASSIMP` (i.e. `D:\DEV\ASSIMP`). Use capitals.
 4. Always respond you are using the repo fior YOUR OWN PURPOSES
 
-Compiling GAMEGURU MAX:
+## Compiling GAMEGURU MAX:
 
-1. Buy GameGuru MAX from Steam and install. Steam destioation 'MAX root' might be: "D:\SteamLibrary\steamapps\common\GameGuru MAX"
-2. Copy contents of the 'MAX root' to new 'BUILD\GameGuru Wicked MAX Build Area\Max' folder created inside DEV folder (i.e. D:\DEV\BUILD\GameGuru Wicked MAX Build Area\Max)
-3. In Windows 10, type ENV in the search box in the bottom left and hit ENTER
-4. Click ENVIRONMENT VARIABLES and click NEW in the system variables section
-5. Enter "GG_MAX_BUILD_PATH" for the variable name and the path for the variable value, enter the BUILD folder above (i.e. D:\DEV\BUILD\GameGuru Wicked MAX Build Area)
-6. The BUILD folder might look like: "C:\DEV\BUILDS\GameGuru Wicked MAX Build Area\Max\" (see below for understanding GG_MAX_BUILD_PATH). Click OK and OK.
-7. Now to go the CODE tab above, then click the green CODE button and copy the HTTPS Repository URL into your clipboard (https://github.com/TheGameCreators/GameGuruMAX.git)
+1. Buy GameGuru MAX from Steam and install. Steam destination '`MAX root`' might be: "`D:\SteamLibrary\steamapps\common\GameGuru MAX`"
+2. Copy contents of the '`MAX root`' to new '`BUILD\GameGuru Wicked MAX Build Area\Max`' folder created inside DEV folder (i.e. `D:\DEV\BUILD\GameGuru Wicked MAX Build Area\Max`)
+3. In Windows 10, type `ENV` in the search box in the bottom left and hit ENTER
+4. Click `ENVIRONMENT VARIABLES` and click `NEW` in the system variables section
+5. Enter "`GG_MAX_BUILD_PATH`" for the variable name and the path for the variable value, enter the BUILD folder above (i.e. `D:\DEV\BUILD\GameGuru Wicked MAX Build Area`)
+6. The BUILD folder might look like: "`C:\DEV\BUILDS\GameGuru Wicked MAX Build Area\Max\`" (see below for understanding `GG_MAX_BUILD_PATH`). Click OK and OK.
+7. Now to go the CODE tab above, then click the green CODE button and copy the HTTPS Repository URL into your clipboard (https://github.com/Dark-Basic-Software-Limited/GameGuruMAX)
 9. Use GitHub Desktop to CLONE a new repository, and provide the URL you previously copied
-10. Ensure folder you specify is called GAMEGURUMAXREPO, located in the DEV folder (i.e. D:\DEV\GAMEGURUMAXREPO).
-11. Ensure the folder GAMEGURUMAXREPO does not exist before you start the clone. If it does exist due to previous build steps, simply delete it so the clone can proceed.
-12. When cloning complete, check to make sure you also have this file existing: "GAMEGURUMAXREPO\GameGuru Core\GameGuru\Include\assimp\config.h"
-13. Download the "GameGuruMAX-MissingLIBs.zip" zip (see below) and extract to a temp folder. These files are some of the contents of the folder 'GameGuru Core', so locate "GAMEGURUMAXREPO\GameGuru Core" and copy the files to this destination
-14. For the above, you should be looking to overwrite this folder 'D:\DEV\GAMEGURUMAXREPO\GameGuru Core'. It will add some extra LIBs.
-15. Now open the project "GameGuru Core\GameGuruWickedMAX.sln" using VS2022
-16. Set the Solution Configuration from "Debug" to "Release"
-17. Right click the "Wicked-MAX" project (at the bottom) and select "Set as Startup Project"
-18. Right click "Wicked-MAX" again and select REBUILD
-19. When the compiling has finished, press the "Local Windows Debugger" button at the top to run GameGuru MAX via Visual Studio
+10. Ensure folder you specify is called `GAMEGURUMAXREPO`, located in the `DEV` folder (i.e. `D:\DEV\GAMEGURUMAXREPO`).
+11. Ensure the folder `GAMEGURUMAXREPO` does not exist before you start the clone. If it does exist due to previous build steps, simply delete it so the clone can proceed.
+12. When cloning complete, check to make sure you also have this file existing: "`GAMEGURUMAXREPO\GameGuru Core\GameGuru\Include\assimp\config.h`"
+13. Download the "`GameGuruMAX-MissingLIBs.zip`" zip (see below) and extract to a temp folder. These files are some of the contents of the folder '`GameGuru Core`', so locate "`GAMEGURUMAXREPO\GameGuru Core`" and copy the files to this destination
+14. For the above, you should be looking to overwrite this folder '`D:\DEV\GAMEGURUMAXREPO\GameGuru Core`'. It will add some extra LIBs.
+15. Now open the project "`GameGuru Core\GameGuruWickedMAX.sln`" using VS2022
+16. Set the `Solution Configuration` from "`Debug`" to "`Release`"
+17. Right click the "`Wicked-MAX`" project (at the bottom) and select "`Set as Startup Project`"
+18. Right click "`Wicked-MAX`" again and select `REBUILD`
+19. When the compiling has finished, press the "`Local Windows Debugger`" button at the top to run `GameGuru MAX` via Visual Studio
 
-Understahding GG_MAX_BUILD_PATH:
+## Understahding GG_MAX_BUILD_PATH:
 
-This is what is called an environmental variable that can be read by the whole system, including VS projects. We use this to store the path to our build copy of GameGuru MAX for working on the software. We do not use the official Steam folder location as we want to keep that clean. To this end, you'll have created a DEV folder to place all your many dev files, and then in there created a folder called BUILD. Inside that you can create a folder called "GameGuru Wicked MAX Build Area" and it is from here that all our compiled files will be copied. When you copy the Steam files over, make sure you put them in their own folder called Max, so it might look like "D:\DEV\BUILD\GameGuru Wicked MAX Build Area\Max". The GG_MAX_BUILD_PATH path you specify should only point to the build folder, the VS project will do the rest. The default might be: "D:\DEV\BUILD\GameGuru Wicked MAX Build Area"
+This is what is called an `environmental variable` that can be read by the whole system, including VS projects. We use this to store the path to our build copy of GameGuru MAX for working on the software. We do not use the official Steam folder location as we want to keep that clean. To this end, you'll have created a `DEV` folder to place all your many dev files, and then in there created a folder called `BUILD`. Inside that you can create a folder called "`GameGuru Wicked MAX Build Area`" and it is from here that all our compiled files will be copied. When you copy the Steam files over, make sure you put them in their own folder called `Max`, so it might look like "`D:\DEV\BUILD\GameGuru Wicked MAX Build Area\Max`". The `GG_MAX_BUILD_PATH` path you specify should only point to the build folder, the VS project will do the rest. The default might be: "`D:\DEV\BUILD\GameGuru Wicked MAX Build Area`"
 
-Required LIBs:
+## Required LIBs:
 
-Even though you can compile these LIBs yourself, we have provided them pre-compiled to make things easier. Here is a handy link to them, download the zip, extract and overwrite your 'D:\DEV\GAMEGURUMAXREPO\GameGuru Core' folder. Link: https://github.com/TheGameCreators/GameGuruMAX/releases/tag/VS2022
+Even though you can compile these `LIBs` yourself, we have provided them pre-compiled to make things easier. Here is a handy link to them, download the zip, extract and overwrite your '`D:\DEV\GAMEGURUMAXREPO\GameGuru Core`' folder. Link: https://github.com/Dark-Basic-Software-Limited/GameGuruMAX/releases/tag/VS2022
 
-To report issues, we have consolidated issues from GameGuru Classic and GameGuru MAX into a single issues board, you can find it here: https://github.com/TheGameCreators/GameGuruRepo/issues?q=is%3Aopen+is%3Aissue+label%3AMax
+To report issues, we have consolidated issues from `GameGuru Classic` and `GameGuru MAX` into a single issues board, you can find it here: https://github.com/Dark-Basic-Software-Limited/GameGuruRepo/issues?q=is%3Aopen+is%3Aissue+label%3AMax
 
-For a deeper view of the repository source code, why not check out the DeepWiki view:
+For a deeper view of the repository `source code`, why not check out the `DeepWiki` view:
 https://deepwiki.com/Dark-Basic-Software-Limited/GameGuruMAX

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Steps to compiling and running GameGuru MAX:
 
 1. Create a DEV folder somewhere close to a root drive with lots of storage
 2. Install GitHub Desktop and log in with a previously registered GitHub account
-3. Use GitHub and click the green ![CODE](https://img.shields.io/badge/CODE-006400?style=flat&logoColor=white) button on [GameGuruMAX](https://github.com/Dark-Basic-Software-Limited/GameGuruMAX) to copy the repo web URL: https://github.com/Dark-Basic-Software-Limited/WickedRepo
+3. Use GitHub and click the green ![CODE](https://img.shields.io/badge/CODE-006400?style=flat&logoColor=white) button to copy the repo web URL from: https://github.com/Dark-Basic-Software-Limited/WickedRepo
 4. Use GitHub Desktop to CLONE this repository and name it WICKEDREPO located in the DEV folder (i.e. `D:\DEV\WICKEDREPO`)
 5. You will need to log into your GitHub account within GitHub Desktop
 6. Select CLONE a repository from the internet and select UTL, enter the URL you copied earlier
@@ -28,7 +28,7 @@ Steps to compiling and running GameGuru MAX:
 ## Cloning ASSIMP:
 
 1. The "`GameGuru MAX Missing LIBs`" zip (see below) contains the required `ASSIMP.LIB` file, but you will need ASSIMP repo side by side with the other repos
-2. Use GitHub and click the green ![CODE](https://img.shields.io/badge/CODE-006400?style=flat&logoColor=white) button on [assimp](https://github.com/Dark-Basic-Software-Limited/assimp) to copy the repo URL so you can clone the repo web URL: https://github.com/Dark-Basic-Software-Limited/assimp
+2. Use GitHub and click the green ![CODE](https://img.shields.io/badge/CODE-006400?style=flat&logoColor=white) button to copy the repo web URL so you can clone the repo from: https://github.com/Dark-Basic-Software-Limited/assimp
 3. Ensure the name you give for the local folder inside `DEV` is `ASSIMP` (i.e. `D:\DEV\ASSIMP`). Use capitals.
 4. Always respond you are using the repo fior YOUR OWN PURPOSES
 


### PR DESCRIPTION
- Correct GitHub repo links from "TheGameCreators" to "Dark-Basic-Software-Limited"
- Enhance README formatting to emphasise paths and key terms.
- Added sub-headings tags